### PR TITLE
refactor: replace anyhow with eyre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,12 +127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-
-[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +149,21 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "base16ct"
@@ -363,6 +381,33 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colorchoice"
@@ -776,6 +821,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +1031,12 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "group"
@@ -1329,6 +1390,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,11 +1506,12 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 name = "jj-rs"
 version = "0.3.0"
 dependencies = [
- "anyhow",
  "chrono",
  "clap",
+ "color-eyre",
  "colored",
  "crossterm 0.29.0",
+ "eyre",
  "flate2",
  "futures-util",
  "http-body-util",
@@ -1769,6 +1837,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,6 +1862,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "p256"
@@ -2428,6 +2511,12 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -3123,6 +3212,16 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.3.0"
 edition = "2024"
 
 [dependencies]
-anyhow = "1.0.100"
 chrono = { version = "0.4.42", features = ["serde"] }
 clap = { version = "4.5.50", features = ["derive"] }
+color-eyre = "0.6.5"
 colored = "3.0.0"
 crossterm = "0.29.0"
+eyre = "0.6.12"
 flate2 = "1.1.5"
 futures-util = "0.3.31"
 http-body-util = "0.1.3"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ pub struct Example {
 }
 
 impl super::Command for Example {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         system("systemctl status ssh")?;
         
         let state = qx("systemctl is-active ssh")?.1;
@@ -138,7 +138,7 @@ impl Default for ExampleTroubleshooter {
 }
 
 impl Troubleshooter for ExampleTroubleshooter {
-    fn checks<'a>(&'a self) -> anyhow::Result<Vec<Box<dyn CheckStep<'a> + 'a>>> {
+    fn checks<'a>(&'a self) -> eyre::Result<Vec<Box<dyn CheckStep<'a> + 'a>>> {
         Ok(vec![
             systemd_service_check("example")
         ])
@@ -177,14 +177,14 @@ As an example, `reqwest`. Under the [feature flags](https://docs.rs/crate/reqwes
 Rust is very specific about how to handle errors. For this project, there are two rules for handling errors:
 
 1. If you are writing a command or a check (anything that goes in `src/commands` or `src/checks`), just use `?` and bubble it up. See the example command above, how after `system` and `qx` it just uses `?`
-2. If you are writing a utility, include `use anyhow::Context;` at the top of your file and use `.context("Add an additional error message here")?` with code that returns a result.
+2. If you are writing a utility, include `use eyre::Context;` at the top of your file and use `.context("Add an additional error message here")?` with code that returns a result.
 
 For situation 2, consider the following example in `src/utils/made_up_util.rs`:
 
 ``` rust
-use anyhow::Context;
+use eyre::Context;
 
-fn do_the_thing() -> anyhow::Result<()> {
+fn do_the_thing() -> eyre::Result<()> {
     crate::utils::system("iptables -A OUTPUT DROP")                 // Function returns Result
         .context("Could not run iptables to drop firewall rules")?; // Context added before using `?`
 }

--- a/src/checks/ssh.rs
+++ b/src/checks/ssh.rs
@@ -1,7 +1,7 @@
 use std::{net::Ipv4Addr, sync::Arc};
 
-use anyhow::Context;
 use chrono::Utc;
+use eyre::Context;
 
 use crate::utils::distro::get_distro;
 
@@ -53,7 +53,7 @@ impl Default for SshTroubleshooter {
 }
 
 impl Troubleshooter for SshTroubleshooter {
-    fn checks<'a>(&'a self) -> anyhow::Result<Vec<Box<dyn super::CheckStep<'a> + 'a>>> {
+    fn checks<'a>(&'a self) -> eyre::Result<Vec<Box<dyn super::CheckStep<'a> + 'a>>> {
         let distro = get_distro().context("could not load distribution for ssh check")?;
 
         Ok(vec![
@@ -101,7 +101,7 @@ impl Troubleshooter for SshTroubleshooter {
 }
 
 impl SshTroubleshooter {
-    fn try_remote_login(&self, tr: &mut dyn TroubleshooterRunner) -> anyhow::Result<CheckResult> {
+    fn try_remote_login(&self, tr: &mut dyn TroubleshooterRunner) -> eyre::Result<CheckResult> {
         let host = self.host;
         let port = self.port;
         let user = self.user.clone();
@@ -140,7 +140,7 @@ impl SshTroubleshooter {
         port: u16,
         user: &str,
         password: &str,
-    ) -> anyhow::Result<CheckResult> {
+    ) -> eyre::Result<CheckResult> {
         struct Client;
 
         impl russh::client::Handler for Client {

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -3,9 +3,9 @@ use std::{
     path::PathBuf,
 };
 
-use anyhow::Context;
 use clap::Parser;
 use colored::Colorize;
+use eyre::Context;
 use flate2::{Compression, write::GzEncoder};
 use tar::Builder;
 use walkdir::WalkDir;
@@ -34,7 +34,7 @@ pub struct Backup {
 }
 
 impl super::Command for Backup {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         // Scope: by forcing this action to be scoped, `archive`, `encoder`, and
         // `initial_tarball` will be closed, allowing
         {

--- a/src/commands/busybox.rs
+++ b/src/commands/busybox.rs
@@ -17,7 +17,7 @@ pub struct Busybox {
 }
 
 impl super::Command for Busybox {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         let bb = busybox::Busybox::new()?;
 
         let args = if self.args.is_empty() {

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -42,7 +42,7 @@ define_checks! {
 }
 
 impl super::Command for Check {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         let mut t = checks::CliTroubleshooter::new(
             self.show_successful_steps,
             self.show_not_run_steps,

--- a/src/commands/check_daemon/logs.rs
+++ b/src/commands/check_daemon/logs.rs
@@ -59,7 +59,7 @@ pub async fn log_handler_thread(
     log_pipe: tokio::net::unix::pipe::Receiver,
     log_event_sender: tokio::sync::mpsc::Sender<LogEvent>,
     mut shutdown: tokio::sync::broadcast::Receiver<()>,
-) -> anyhow::Result<()> {
+) -> eyre::Result<()> {
     // into_blocking_fd unregisters it from the previous tokio runtime it was
     // created on, and from_owned_fd registers it on the current runtime
     let mut log_pipe =

--- a/src/commands/check_daemon/tui.rs
+++ b/src/commands/check_daemon/tui.rs
@@ -11,7 +11,7 @@
 //     _prompt_reader: Receiver,
 //     _answer_writer: Sender,
 //     _scope: &std::thread::Scope<'_, '_>,
-// ) -> anyhow::Result<()> {
+// ) -> eyre::Result<()> {
 //     let mut terminal = ratatui::init();
 //     loop {
 //         terminal.draw(|frame| {

--- a/src/commands/download_shell.rs
+++ b/src/commands/download_shell.rs
@@ -6,8 +6,8 @@ use std::{
     process::{Command, exit},
 };
 
-use anyhow::Context;
 use clap::{Parser, ValueEnum};
+use eyre::Context;
 use flate2::write::GzDecoder;
 use nix::{
     sys::{
@@ -48,7 +48,7 @@ pub struct DownloadShell {
     command: Vec<String>,
 }
 
-fn zsh_command() -> anyhow::Result<(OwnedFd, Command)> {
+fn zsh_command() -> eyre::Result<(OwnedFd, Command)> {
     let temp_fd = memfd_create("", MFdFlags::empty())?;
     let raw_fd = temp_fd.into_raw_fd();
 
@@ -67,7 +67,7 @@ fn zsh_command() -> anyhow::Result<(OwnedFd, Command)> {
 }
 
 impl super::Command for DownloadShell {
-    fn execute(mut self) -> anyhow::Result<()> {
+    fn execute(mut self) -> eyre::Result<()> {
         let container = DownloadContainer::new(self.name.take(), self.sneaky_ip)?;
 
         let bash_cmd = format!(
@@ -79,7 +79,7 @@ impl super::Command for DownloadShell {
 
         let sh_ps1 = format!(r"\033[0;32m({})\033[0m \u@\h:\w\$ ", container.name());
 
-        container.run(|| -> anyhow::Result<()> {
+        container.run(|| -> eyre::Result<()> {
             match (
                 std::env::var("SUDO_UID")
                     .ok()

--- a/src/commands/enum.rs
+++ b/src/commands/enum.rs
@@ -7,7 +7,7 @@ use crate::utils::{busybox::Busybox, qx};
 pub struct Enum;
 
 impl super::Command for Enum {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         let bb = Busybox::new()?;
 
         println!("\n==== CPU INFO\n");

--- a/src/commands/firewall.rs
+++ b/src/commands/firewall.rs
@@ -35,7 +35,7 @@ pub struct Firewall {
 }
 
 impl super::Command for Firewall {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         match self.cmd {
             FirewallCmd::QuickSetup(qs) => qs.execute(),
             FirewallCmd::NatRedirect(nr) => nr.execute(),
@@ -63,7 +63,7 @@ struct QuickSetup {
 }
 
 impl QuickSetup {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         let sockets = parse_ports()?;
 
         let mut ob: Box<dyn Write> = match self.output_file {
@@ -194,7 +194,7 @@ struct NatRedirect {
 }
 
 impl NatRedirect {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         let nft = Nft::new()?;
 
         let NatRedirect {

--- a/src/commands/jq.rs
+++ b/src/commands/jq.rs
@@ -6,8 +6,8 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::Context;
 use clap::Parser;
+use eyre::Context;
 use flate2::write::GzDecoder;
 use nix::{
     sys::memfd::{MFdFlags, memfd_create},
@@ -33,7 +33,7 @@ pub struct Jq {
 const JQ_BYTES: &[u8] = include_bytes!(std::env!("JQ_GZIPPED"));
 
 impl super::Command for Jq {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         let temp_fd =
             memfd_create("", MFdFlags::empty()).context("Could not create memory file")?;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,5 +18,5 @@ pub mod useradd;
 pub mod zsh;
 
 pub trait Command: clap::Parser {
-    fn execute(self) -> anyhow::Result<()>;
+    fn execute(self) -> eyre::Result<()>;
 }

--- a/src/commands/nft.rs
+++ b/src/commands/nft.rs
@@ -17,7 +17,7 @@ pub struct Nft {
 }
 
 impl super::Command for Nft {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         let nft = nft::Nft::new()?;
 
         nft.command().args(self.args).spawn()?.wait()?;

--- a/src/commands/ports.rs
+++ b/src/commands/ports.rs
@@ -8,7 +8,7 @@ use crate::utils::ports::{self, SocketState};
 pub struct Ports;
 
 impl super::Command for Ports {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         let tcp_ports = ports::parse_net_tcp()?;
 
         println!(

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -26,7 +26,7 @@ pub struct Serve {
 }
 
 impl super::Command for Serve {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?
@@ -36,7 +36,7 @@ impl super::Command for Serve {
     }
 }
 
-async fn serve(args: Serve) -> anyhow::Result<()> {
+async fn serve(args: Serve) -> eyre::Result<()> {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer())
         .init();
@@ -68,7 +68,7 @@ async fn serve(args: Serve) -> anyhow::Result<()> {
     }
 }
 
-fn not_found() -> anyhow::Result<Response<BoxBody<Bytes, std::io::Error>>> {
+fn not_found() -> eyre::Result<Response<BoxBody<Bytes, std::io::Error>>> {
     let body = Full::new(Bytes::from("404"))
         .map_err(std::io::Error::other)
         .boxed();
@@ -81,7 +81,7 @@ fn not_found() -> anyhow::Result<Response<BoxBody<Bytes, std::io::Error>>> {
 async fn respond(
     root_path: PathBuf,
     req: Request<hyper::body::Incoming>,
-) -> anyhow::Result<Response<BoxBody<Bytes, std::io::Error>>> {
+) -> eyre::Result<Response<BoxBody<Bytes, std::io::Error>>> {
     let mut path = root_path.clone();
     let uri = req.uri();
 
@@ -134,7 +134,7 @@ async fn respond_dir(
     req: &Request<hyper::body::Incoming>,
     path: PathBuf,
     uri: String,
-) -> anyhow::Result<Response<BoxBody<Bytes, std::io::Error>>> {
+) -> eyre::Result<Response<BoxBody<Bytes, std::io::Error>>> {
     let entries = tokio::fs::read_dir(&path).await?;
     let entries = ReadDirStream::new(entries)
         .collect::<Result<Vec<_>, _>>()
@@ -252,7 +252,7 @@ async fn respond_dir(
     Ok(Response::builder().status(StatusCode::OK).body(body)?)
 }
 
-async fn respond_file(path: PathBuf) -> anyhow::Result<Response<BoxBody<Bytes, std::io::Error>>> {
+async fn respond_file(path: PathBuf) -> eyre::Result<Response<BoxBody<Bytes, std::io::Error>>> {
     let file = tokio::fs::File::open(path).await?;
     let reader_stream = ReaderStream::new(file);
 

--- a/src/commands/ssh.rs
+++ b/src/commands/ssh.rs
@@ -14,7 +14,7 @@ pub enum SshCommands {
 }
 
 impl super::Command for Ssh {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         match self.command {
             SshCommands::Check(ssh_troubleshooter) => {
                 let mut t = crate::utils::checks::CliTroubleshooter::new(false, false, false);

--- a/src/commands/stat.rs
+++ b/src/commands/stat.rs
@@ -17,7 +17,7 @@ pub enum StatCommands {
 }
 
 impl super::Command for Stat {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         match self.command {
             StatCommands::Cpu => {
                 let stat = std::fs::read_to_string("/proc/stat")?;

--- a/src/commands/tcpdump.rs
+++ b/src/commands/tcpdump.rs
@@ -17,7 +17,7 @@ pub struct Tcpdump {
 }
 
 impl super::Command for Tcpdump {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         let tcpdump = tcpdump::Tcpdump::new()?;
 
         tcpdump.command(&self.args, None)?;

--- a/src/commands/tmux.rs
+++ b/src/commands/tmux.rs
@@ -6,8 +6,8 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::Context;
 use clap::Parser;
+use eyre::Context;
 use flate2::write::GzDecoder;
 use nix::{
     sys::memfd::{MFdFlags, memfd_create},
@@ -31,7 +31,7 @@ pub struct Tmux {
 const TMUX_BYTES: &[u8] = include_bytes!(std::env!("TMUX_GZIPPED"));
 
 impl super::Command for Tmux {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         let temp_fd =
             memfd_create("", MFdFlags::empty()).context("Could not create memory file")?;
 

--- a/src/commands/useradd.rs
+++ b/src/commands/useradd.rs
@@ -1,4 +1,4 @@
-use anyhow::bail;
+use eyre::bail;
 use nix::unistd::geteuid;
 
 use crate::{
@@ -19,7 +19,7 @@ pub struct Useradd {
 }
 
 impl super::Command for Useradd {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         if !geteuid().is_root() {
             bail!("You must be root to add backup users");
         }

--- a/src/commands/zsh.rs
+++ b/src/commands/zsh.rs
@@ -10,8 +10,8 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::Context;
 use clap::Parser;
+use eyre::Context;
 use flate2::write::GzDecoder;
 use nix::{
     sys::memfd::{MFdFlags, memfd_create},
@@ -52,7 +52,7 @@ pub struct Zsh {
 pub const ZSH_BYTES: &[u8] = include_bytes!(std::env!("ZSH_GZIPPED"));
 
 impl super::Command for Zsh {
-    fn execute(self) -> anyhow::Result<()> {
+    fn execute(self) -> eyre::Result<()> {
         if self.install {
             let mut file = std::fs::OpenOptions::new()
                 .write(true)
@@ -63,7 +63,7 @@ impl super::Command for Zsh {
 
             let current_file = std::env::args()
                 .next()
-                .ok_or(anyhow::anyhow!("Could not get current binary"))?;
+                .ok_or(eyre::eyre!("Could not get current binary"))?;
 
             writeln!(file, "#!{} zsh", &current_file)?;
             writeln!(file, "exec {} zsh $@", &current_file)?;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -12,7 +12,7 @@ macro_rules! define_commands {
         }
 
         impl Commands {
-            fn execute(self) -> anyhow::Result<()> {
+            fn execute(self) -> eyre::Result<()> {
                 use $crate::commands::Command;
 
                 fn _type_check<F: $crate::commands::Command>(_a: &F) {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,8 @@ struct Cli {
     command: Commands,
 }
 
-fn main() -> anyhow::Result<()> {
+fn main() -> eyre::Result<()> {
     let cli = Cli::parse();
+    color_eyre::install()?;
     cli.command.execute()
 }

--- a/src/utils/busybox.rs
+++ b/src/utils/busybox.rs
@@ -4,7 +4,7 @@
 //!
 //! ```
 //! # use jj_rs::utils::busybox::Busybox;
-//! # fn test_busybox() -> anyhow::Result<()> {
+//! # fn test_busybox() -> eyre::Result<()> {
 //! let busybox = Busybox::new()?;
 //!
 //! assert_eq!(busybox.execute(&["uname"])?, "Linux\n");
@@ -30,7 +30,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{Context, bail};
+use eyre::{Context, bail};
 use flate2::write::GzDecoder;
 use nix::{
     sys::memfd::{MFdFlags, memfd_create},
@@ -40,7 +40,7 @@ use nix::{
 const BUSYBOX_BYTES: &[u8] = include_bytes!(std::env!("BUSYBOX_GZIPPED"));
 
 /// Utility function for converting a list of Strings or strs to a list `CStrings`
-pub fn str_to_cstr<R: AsRef<str>>(args: &[R]) -> anyhow::Result<Vec<CString>> {
+pub fn str_to_cstr<R: AsRef<str>>(args: &[R]) -> eyre::Result<Vec<CString>> {
     args.iter()
         .map(|arg| CString::from_str(arg.as_ref()))
         .collect::<Result<Vec<CString>, _>>()
@@ -51,7 +51,7 @@ pub fn str_to_cstr<R: AsRef<str>>(args: &[R]) -> anyhow::Result<Vec<CString>> {
 ///
 /// ```
 /// # use jj_rs::utils::busybox::Busybox;
-/// # fn test_busybox() -> anyhow::Result<()> {
+/// # fn test_busybox() -> eyre::Result<()> {
 /// let busybox = Busybox::new()?;
 ///
 /// assert_eq!(busybox.execute(&["uname"])?, "Linux\n");
@@ -72,7 +72,7 @@ pub struct Busybox {
 impl Busybox {
     /// Creates a new Busybox container, loading Busybox into memory and preparing to
     /// execute commands
-    pub fn new() -> anyhow::Result<Self> {
+    pub fn new() -> eyre::Result<Self> {
         let temp_fd =
             memfd_create("", MFdFlags::empty()).context("Could not create memory file")?;
 
@@ -95,7 +95,7 @@ impl Busybox {
     /// Replaces the current process with busybox
     ///
     /// In the happy path, good case, this function will fail to return
-    pub fn execv<R: AsRef<str>>(&self, args: &[R]) -> anyhow::Result<()> {
+    pub fn execv<R: AsRef<str>>(&self, args: &[R]) -> eyre::Result<()> {
         let args = str_to_cstr(args)?;
 
         execv(
@@ -112,7 +112,7 @@ impl Busybox {
     ///
     /// ```
     /// # use jj_rs::utils::busybox::Busybox;
-    /// # fn test_busybox() -> anyhow::Result<()> {
+    /// # fn test_busybox() -> eyre::Result<()> {
     /// let busybox = Busybox::new()?;
     ///
     /// assert_eq!(busybox.execute(&["uname"])?, "Linux\n");
@@ -126,7 +126,7 @@ impl Busybox {
     /// # }
     /// # test_busybox().expect("could not run busybox test");
     /// ```
-    pub fn execute<R: AsRef<OsStr>>(&self, command: &[R]) -> anyhow::Result<String> {
+    pub fn execute<R: AsRef<OsStr>>(&self, command: &[R]) -> eyre::Result<String> {
         let Some(cmd) = command.first() else {
             bail!("Command not fully specified; empty list provided to Busybox::execute");
         };
@@ -153,14 +153,14 @@ impl Busybox {
 ///
 /// ```
 /// # use jj_rs::utils::busybox::execute;
-/// # fn test_busybox() -> anyhow::Result<()> {
+/// # fn test_busybox() -> eyre::Result<()> {
 /// assert_eq!(execute(&["uname"])?, "Linux\n");
 /// # Ok(())
 /// # }
 /// # assert!(test_busybox().is_ok());
 /// ```
 #[allow(dead_code)]
-pub fn execute<R: AsRef<OsStr>>(args: &[R]) -> anyhow::Result<String> {
+pub fn execute<R: AsRef<OsStr>>(args: &[R]) -> eyre::Result<String> {
     let busybox = Busybox::new()?;
     busybox.execute(args)
 }

--- a/src/utils/checks/check_fns/binary_ports_check.rs
+++ b/src/utils/checks/check_fns/binary_ports_check.rs
@@ -1,6 +1,6 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use anyhow::Context;
+use eyre::Context;
 
 use crate::utils::{
     checks::{CheckResult, CheckStep, TroubleshooterRunner},
@@ -21,7 +21,7 @@ impl CheckStep<'_> for BinaryPortsCheck {
         "Sockstat check"
     }
 
-    fn run_check(&self, _tr: &mut dyn TroubleshooterRunner) -> anyhow::Result<CheckResult> {
+    fn run_check(&self, _tr: &mut dyn TroubleshooterRunner) -> eyre::Result<CheckResult> {
         if !self.run_local {
             return Ok(CheckResult::not_run(
                 "Cannot check listening ports on a remote system",

--- a/src/utils/checks/check_fns/check_fn.rs
+++ b/src/utils/checks/check_fns/check_fn.rs
@@ -4,7 +4,7 @@ use crate::utils::checks::{CheckResult, CheckStep, TroubleshooterRunner};
 
 struct CheckFn<'a, F>
 where
-    F: Fn(&mut dyn TroubleshooterRunner) -> anyhow::Result<CheckResult> + 'a,
+    F: Fn(&mut dyn TroubleshooterRunner) -> eyre::Result<CheckResult> + 'a,
 {
     name: &'static str,
     check_fn: F,
@@ -13,13 +13,13 @@ where
 
 impl<'a, F> CheckStep<'a> for CheckFn<'a, F>
 where
-    F: Fn(&mut dyn TroubleshooterRunner) -> anyhow::Result<CheckResult> + 'a,
+    F: Fn(&mut dyn TroubleshooterRunner) -> eyre::Result<CheckResult> + 'a,
 {
     fn name(&self) -> &'static str {
         self.name
     }
 
-    fn run_check(&self, tr: &mut dyn TroubleshooterRunner) -> anyhow::Result<CheckResult> {
+    fn run_check(&self, tr: &mut dyn TroubleshooterRunner) -> eyre::Result<CheckResult> {
         (self.check_fn)(tr)
     }
 }
@@ -40,7 +40,7 @@ where
 /// ```
 pub fn check_fn<'a, F>(name: &'static str, f: F) -> Box<dyn CheckStep<'a> + 'a>
 where
-    F: Fn(&mut dyn TroubleshooterRunner) -> anyhow::Result<CheckResult> + 'a,
+    F: Fn(&mut dyn TroubleshooterRunner) -> eyre::Result<CheckResult> + 'a,
 {
     Box::new(CheckFn {
         name,

--- a/src/utils/checks/check_fns/filter_check.rs
+++ b/src/utils/checks/check_fns/filter_check.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use eyre::Context;
 
 use crate::utils::{
     checks::{CheckResult, CheckStep, TroubleshooterRunner},
@@ -60,7 +60,7 @@ where
         self.check.name()
     }
 
-    fn run_check(&self, tr: &mut dyn TroubleshooterRunner) -> anyhow::Result<CheckResult> {
+    fn run_check(&self, tr: &mut dyn TroubleshooterRunner) -> eyre::Result<CheckResult> {
         let distro = crate::utils::distro::get_distro().context(
             "Could not query current Linux distribution to determine if a check should run",
         )?;

--- a/src/utils/checks/check_fns/immediate_tcpdump_check.rs
+++ b/src/utils/checks/check_fns/immediate_tcpdump_check.rs
@@ -3,7 +3,7 @@ use std::{
     net::{Ipv4Addr, TcpStream, UdpSocket},
 };
 
-use anyhow::Context;
+use eyre::Context;
 use futures_util::StreamExt;
 
 use crate::utils::{
@@ -25,12 +25,12 @@ impl ImmediateTcpdumpCheck {
         &self,
         wan_ip: Ipv4Addr,
         lan_device: &str,
-    ) -> anyhow::Result<pcap::PacketStream<pcap::Active, TcpdumpCodec>> {
+    ) -> eyre::Result<pcap::PacketStream<pcap::Active, TcpdumpCodec>> {
         let device = pcap::Device::list()
             .context("Could not list pcap devices")?
             .into_iter()
             .find(|dev| dev.name == lan_device)
-            .ok_or(anyhow::anyhow!("Could not find pcap device"))?;
+            .ok_or(eyre::eyre!("Could not find pcap device"))?;
 
         let capture = pcap::Capture::from_device(device)
             .context("Could not load packet capture device for tcpdump check")?
@@ -77,7 +77,7 @@ impl ImmediateTcpdumpCheck {
         inbound_packet_count: &mut usize,
         outbound_packet_count: &mut usize,
         capture: &mut pcap::PacketStream<pcap::Active, TcpdumpCodec>,
-    ) -> anyhow::Result<u16> {
+    ) -> eyre::Result<u16> {
         loop {
             let Some(Ok((header, packet))) = capture.next().await else {
                 continue;
@@ -215,7 +215,7 @@ impl ImmediateTcpdumpCheck {
         }
     }
 
-    fn make_connection(&self, container: &DownloadContainer) -> anyhow::Result<u16> {
+    fn make_connection(&self, container: &DownloadContainer) -> eyre::Result<u16> {
         let ImmediateTcpdumpCheck {
             port,
             protocol,
@@ -239,7 +239,7 @@ impl ImmediateTcpdumpCheck {
             .flatten()
     }
 
-    async fn run_check(&self) -> anyhow::Result<CheckResult> {
+    async fn run_check(&self) -> eyre::Result<CheckResult> {
         let container = DownloadContainer::new(None, None)
             .context("Could not create download container for immediate tcpdump check")?;
 
@@ -333,7 +333,7 @@ impl ImmediateTcpdumpCheck {
 
         let actual_source_port = unsafe {
             (*sync).err.map_err(|()| {
-                anyhow::anyhow!("Could not perform net connection and specify source port")
+                eyre::eyre!("Could not perform net connection and specify source port")
             })
         };
 
@@ -388,7 +388,7 @@ impl CheckStep<'_> for ImmediateTcpdumpCheck {
         "Verify firewall with tcpdump"
     }
 
-    fn run_check(&self, _tr: &mut dyn TroubleshooterRunner) -> anyhow::Result<CheckResult> {
+    fn run_check(&self, _tr: &mut dyn TroubleshooterRunner) -> eyre::Result<CheckResult> {
         if !self.should_run {
             return Ok(CheckResult::not_run(
                 "Cannot check tcpdump when packets do not return to system via NAT reflection"

--- a/src/utils/checks/check_fns/pam_check.rs
+++ b/src/utils/checks/check_fns/pam_check.rs
@@ -16,7 +16,7 @@ impl CheckStep<'_> for PamCheck {
         "PAM check"
     }
 
-    fn run_check(&self, tr: &mut dyn TroubleshooterRunner) -> anyhow::Result<CheckResult> {
+    fn run_check(&self, tr: &mut dyn TroubleshooterRunner) -> eyre::Result<CheckResult> {
         if !self.run_local {
             return Ok(CheckResult::not_run(
                 "Cannot run check on remote systems",
@@ -115,7 +115,7 @@ impl PamCheck {
         }
     }
 
-    fn get_service_config_internal(&self, service: &str) -> anyhow::Result<serde_json::Value> {
+    fn get_service_config_internal(&self, service: &str) -> eyre::Result<serde_json::Value> {
         let pam_raw = self.read_pam_file(format!("/etc/pam.d/{service}"))?;
 
         let auth = pam_raw.iter().filter_map(|l| {
@@ -147,7 +147,7 @@ impl PamCheck {
         }))
     }
 
-    fn read_pam_file<P: AsRef<Path>>(&self, file: P) -> anyhow::Result<Vec<String>> {
+    fn read_pam_file<P: AsRef<Path>>(&self, file: P) -> eyre::Result<Vec<String>> {
         Ok(std::fs::read_to_string(file)?
             .split('\n')
             .flat_map(|line| {

--- a/src/utils/checks/check_fns/service_checks.rs
+++ b/src/utils/checks/check_fns/service_checks.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use eyre::Context;
 
 use crate::utils::{
     checks::{CheckResult, CheckStep, TroubleshooterRunner},
@@ -15,7 +15,7 @@ impl CheckStep<'_> for SystemdServiceCheck {
         "Check systemd service"
     }
 
-    fn run_check(&self, _tr: &mut dyn TroubleshooterRunner) -> anyhow::Result<CheckResult> {
+    fn run_check(&self, _tr: &mut dyn TroubleshooterRunner) -> eyre::Result<CheckResult> {
         if qx("which systemctl 2>/dev/null")?.1.trim().is_empty() {
             return Ok(CheckResult::not_run(
                 "`systemctl` not found on host",
@@ -68,7 +68,7 @@ impl CheckStep<'_> for OpenrcServiceCheck {
         "Check openrc service"
     }
 
-    fn run_check(&self, _tr: &mut dyn TroubleshooterRunner) -> anyhow::Result<CheckResult> {
+    fn run_check(&self, _tr: &mut dyn TroubleshooterRunner) -> eyre::Result<CheckResult> {
         if qx("which rc-service 2>/dev/null")?.1.trim().is_empty() {
             return Ok(CheckResult::not_run(
                 "`rc-service` not found on host",

--- a/src/utils/checks/check_fns/tcp_connect_check.rs
+++ b/src/utils/checks/check_fns/tcp_connect_check.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, SocketAddr, TcpStream};
 
-use anyhow::Context;
+use eyre::Context;
 
 use crate::utils::{
     checks::{CheckResult, CheckStep, TroubleshooterRunner},
@@ -17,7 +17,7 @@ impl CheckStep<'_> for TcpConnectCheck {
         "Check TCP port status"
     }
 
-    fn run_check(&self, _tr: &mut dyn TroubleshooterRunner) -> anyhow::Result<CheckResult> {
+    fn run_check(&self, _tr: &mut dyn TroubleshooterRunner) -> eyre::Result<CheckResult> {
         let timeout = std::time::Duration::from_secs(2);
 
         if self.ip.is_loopback() {

--- a/src/utils/distro.rs
+++ b/src/utils/distro.rs
@@ -65,7 +65,7 @@ impl From<&str> for Distro {
 
 /// Load the current distribution. May fail if there is a malformed
 /// /etc/os-release file
-pub fn get_distro() -> anyhow::Result<Option<Distro>> {
+pub fn get_distro() -> eyre::Result<Option<Distro>> {
     let env = std::fs::read_to_string("/etc/os-release")?;
 
     let matches = pcre!(

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! Not all commands are going to require the same consistency to run on all systems, and
 //! those modules can relax and use the tools from category 2
-use anyhow::Context;
+use eyre::Context;
 
 use std::{fs::OpenOptions, path::Path, process::ExitStatus};
 
@@ -29,7 +29,7 @@ pub mod tcpdump;
 ///
 /// ```
 /// # use jj_rs::utils::qx;
-/// # fn demo_qx() -> anyhow::Result<()> {
+/// # fn demo_qx() -> eyre::Result<()> {
 /// let os = qx("uname")?.1;
 /// assert_eq!(os, "Linux\n");
 /// assert_eq!(os.trim(), "Linux");
@@ -37,7 +37,7 @@ pub mod tcpdump;
 /// # }
 /// # assert!(demo_qx().is_ok());
 /// ```
-pub fn qx(command: &str) -> anyhow::Result<(ExitStatus, String)> {
+pub fn qx(command: &str) -> eyre::Result<(ExitStatus, String)> {
     let output = std::process::Command::new("sh")
         .args(["-c", command])
         .stderr(std::process::Stdio::piped())
@@ -59,7 +59,7 @@ pub fn qx(command: &str) -> anyhow::Result<(ExitStatus, String)> {
 /// assert!(system("true").unwrap().success());
 /// assert!(!system("false").unwrap().success());
 /// ```
-pub fn system(command: &str) -> anyhow::Result<ExitStatus> {
+pub fn system(command: &str) -> eyre::Result<ExitStatus> {
     std::process::Command::new("/bin/sh")
         .args(["-c", command])
         .spawn()
@@ -72,12 +72,12 @@ pub fn system(command: &str) -> anyhow::Result<ExitStatus> {
 ///
 /// ```no_run
 /// # use jj_rs::utils::download_file;
-/// # fn demo_download() -> anyhow::Result<()> {
+/// # fn demo_download() -> eyre::Result<()> {
 /// download_file("https://artifacts.elastic.co/elasticsearch/elasticsearch-9.2.0-amd64.deb", "/tmp/elasticsearch.deb")?;
 /// # Ok(())
 /// # }
 /// ```
-pub fn download_file<P: AsRef<Path>>(url: &str, to: P) -> anyhow::Result<()> {
+pub fn download_file<P: AsRef<Path>>(url: &str, to: P) -> eyre::Result<()> {
     let mut target_file = OpenOptions::new()
         .truncate(true)
         .create(true)

--- a/src/utils/nft.rs
+++ b/src/utils/nft.rs
@@ -4,7 +4,7 @@
 //! ```no_run
 //! # // don't run the unit test to delete the firewall...
 //! # use jj_rs::utils::nft::Nft;
-//! # fn test_nft() -> anyhow::Result<()> {
+//! # fn test_nft() -> eyre::Result<()> {
 //! let nft = Nft::new()?;
 //!
 //! nft.exec("flush ruleset", None)?;
@@ -19,7 +19,7 @@ use std::{
     process::{Command, ExitStatus, Stdio},
 };
 
-use anyhow::Context;
+use eyre::Context;
 use flate2::write::GzDecoder;
 use nix::sys::memfd::{MFdFlags, memfd_create};
 
@@ -32,7 +32,7 @@ pub struct Nft {
 
 impl Nft {
     /// Create a new nft handle that can be used later to manipulate firewall rules
-    pub fn new() -> anyhow::Result<Self> {
+    pub fn new() -> eyre::Result<Self> {
         let temp_fd =
             memfd_create("", MFdFlags::empty()).context("Could not create memory file")?;
 
@@ -57,7 +57,7 @@ impl Nft {
     /// ```no_run
     /// # // don't run the unit test to add a chain called "sneaky_ip"...
     /// # use jj_rs::utils::nft::Nft;
-    /// # fn test_nft() -> anyhow::Result<()> {
+    /// # fn test_nft() -> eyre::Result<()> {
     /// let nft = Nft::new()?;
     ///
     /// nft.exec("add table inet sneaky_shell", None)?;
@@ -69,7 +69,7 @@ impl Nft {
         &self,
         command: R,
         stderr: S,
-    ) -> anyhow::Result<ExitStatus> {
+    ) -> eyre::Result<ExitStatus> {
         Command::new(format!("/proc/self/fd/{}", self.nft_file.as_raw_fd()))
             .arg(command.as_ref())
             .stderr(stderr.into().unwrap_or_else(Stdio::inherit))

--- a/src/utils/pamtester.rs
+++ b/src/utils/pamtester.rs
@@ -4,7 +4,7 @@
 //! ```no_run
 //! # // don't run the unit test to authenticate as root...
 //! # use jj_rs::utils::pamtester::Pamtester;
-//! # fn test_pamtester() -> anyhow::Result<()> {
+//! # fn test_pamtester() -> eyre::Result<()> {
 //! let pamtester = Pamtester::new()?;
 //! pamtester.command().args(["login", "root", "authenticate"]).spawn()?.wait()?;
 //! # Ok(())
@@ -21,7 +21,7 @@ use std::{
     process::Command,
 };
 
-use anyhow::Context;
+use eyre::Context;
 use flate2::write::GzDecoder;
 use nix::sys::memfd::{MFdFlags, memfd_create};
 
@@ -34,7 +34,7 @@ pub struct Pamtester {
 
 impl Pamtester {
     /// Create a new pamtester handle that can be used later to manipulate firewall rules
-    pub fn new() -> anyhow::Result<Self> {
+    pub fn new() -> eyre::Result<Self> {
         let temp_fd =
             memfd_create("", MFdFlags::empty()).context("Could not create memory file")?;
 

--- a/src/utils/passwd.rs
+++ b/src/utils/passwd.rs
@@ -23,7 +23,7 @@ pub struct Passwd {
 ///
 /// ```
 /// # use jj_rs::utils::passwd::load_users;
-/// # fn test_load_users() -> anyhow::Result<()> {
+/// # fn test_load_users() -> eyre::Result<()> {
 /// // load all users
 /// let users = load_users::<_, &str>(None)?;
 /// for user in users {
@@ -36,7 +36,7 @@ pub struct Passwd {
 ///
 /// ```
 /// # use jj_rs::utils::passwd::load_users;
-/// # fn test_load_users() -> anyhow::Result<()> {
+/// # fn test_load_users() -> eyre::Result<()> {
 /// // load a specific user
 /// let root = &load_users("root")?[0];
 /// assert_eq!(&root.user, "root");
@@ -48,7 +48,7 @@ pub struct Passwd {
 /// # }
 /// # test_load_users().expect("could not load root");
 /// ```
-pub fn load_users<I: Into<Option<S>>, S: AsRef<str>>(uid: I) -> anyhow::Result<Vec<Passwd>> {
+pub fn load_users<I: Into<Option<S>>, S: AsRef<str>>(uid: I) -> eyre::Result<Vec<Passwd>> {
     // getent passwd works better for domain joined systems and systems with weird
     // /etc/nsswitch.conf, but fall back to directly reading from /etc/passwd
     let cmd = match uid.into() {

--- a/src/utils/systemd.rs
+++ b/src/utils/systemd.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use anyhow::Context;
+use eyre::Context;
 
 use crate::{pcre, utils::qx};
 
@@ -15,7 +15,7 @@ pub fn is_service_active(service_info: &HashMap<String, String>) -> bool {
 }
 
 /// Pull state and configuration information about a systemd unit
-pub fn get_service_info(service: &str) -> anyhow::Result<HashMap<String, String>> {
+pub fn get_service_info(service: &str) -> eyre::Result<HashMap<String, String>> {
     let service_info = qx(&format!("systemctl show --no-pager {service}"))
         .context("Could not show service info")?
         .1;

--- a/src/utils/tcpdump.rs
+++ b/src/utils/tcpdump.rs
@@ -7,9 +7,9 @@
 //!
 //! ```no_run
 //! # use std::{io::{BufReader, prelude::*}, process::Stdio};
-//! # use anyhow::anyhow;
+//! # use eyre::eyre;
 //! # use jj_rs::utils::tcpdump::Tcpdump;
-//! # fn test_tcpdump() -> anyhow::Result<()> {
+//! # fn test_tcpdump() -> eyre::Result<()> {
 //! let tcpdump = Tcpdump::new()?;
 //! let mut command: std::process::Command = tcpdump.command_inst();
 //!
@@ -17,7 +17,7 @@
 //!     .stdout(Stdio::inherit())
 //!     .spawn()?;
 //!
-//! let stdout = child.stdout.take().ok_or(anyhow!("Could not get stdout"))?;
+//! let stdout = child.stdout.take().ok_or(eyre!("Could not get stdout"))?;
 //! let mut stdout = BufReader::new(stdout);
 //!
 //! for line in stdout.lines() {
@@ -36,7 +36,7 @@ use std::{
     process::{Command, ExitStatus, Stdio},
 };
 
-use anyhow::Context;
+use eyre::Context;
 use flate2::write::GzDecoder;
 use nix::sys::memfd::{MFdFlags, memfd_create};
 
@@ -49,7 +49,7 @@ pub struct Tcpdump {
 
 impl Tcpdump {
     /// Create a new Tcpdump handle to prepare for execution of commands
-    pub fn new() -> anyhow::Result<Self> {
+    pub fn new() -> eyre::Result<Self> {
         let temp_fd =
             memfd_create("", MFdFlags::empty()).context("Could not create memory file")?;
 
@@ -80,7 +80,7 @@ impl Tcpdump {
         &self,
         args: &[R],
         stderr: S,
-    ) -> anyhow::Result<ExitStatus> {
+    ) -> eyre::Result<ExitStatus> {
         Command::new(format!("/proc/self/fd/{}", self.tcpdump_file.as_raw_fd()))
             .args(args)
             .stderr(stderr.into().unwrap_or_else(Stdio::inherit))


### PR DESCRIPTION
Anyhow was included due to the use of the `.context` function with the understanding that it would maintain context from previous Result types. However, this is not supported in anyhow like it is in eyre