### PR TITLE
fix: configure checkout action to pull LFS files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
       contents: "write"
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: cachix/install-nix-action@v31
       - uses: cachix/cachix-action@v16
         with:


### PR DESCRIPTION
This should fix dashboards not loading from full github releases